### PR TITLE
Add `FURIOSA_METADATA_EXPECT_MODIFIED` for fine-grained dirty detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.23"
+glob = "0.3.1"


### PR DESCRIPTION
Cargo.toml의 버전 정보를 변경해서 빌드하는 경우 git working copy가 변경되기 때문에 의도치 않게 `-modified`가 `GIT_SHORT_HASH`에 붙는 문제가 있습니다. Cargo.toml을 고치지 않는 것이 최선이겠습니다만 현재 달리 다른 방법이 없기 때문에 (rust-lang/cargo#6583 등을 참고) 변경되어도 무시하도록 하는 환경 변수를 추가하여 문제를 우회하도록 합니다.

해당 환경 변수는 `FURIOSA_METADATA_EXPECT_MODIFIED=Cargo.toml,Cargo.lock`과 같이 사용할 수 있습니다. 콤마로 여러 패턴을 지정하는 건 본래 [glob](https://github.com/rust-lang/glob) 내장 기능은 아니지만 이와 같은 상황에서 필요하다고 판단하여 가벼운 방법으로 지원을 추가하였습니다.