### PR TITLE
Enhance debugging: Improve logging for FURIOSA_METADATA_EXPECT_MODIFIED patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ fn get_expected_patterns() -> Result<Vec<Pattern>, Box<dyn std::error::Error>> {
         Ok(patterns) => patterns
             .split(':')
             .map(|pattern| {
+                eprintln!("FURIOSA_METADATA_EXPECT_MODIFIED={pattern}");
                 if pattern.is_empty() {
                     Err(format!("{PATTERN_VAR} contains an empty pattern").into())
                 } else {
@@ -135,6 +136,9 @@ fn git_short_hash(expected_patterns: &[Pattern]) -> Result<String, Box<dyn std::
                         "[furiosa-metadata] Ignored an updated file {path:?} as it was expected."
                     );
                 } else {
+                    eprintln!(
+                        "[furiosa-metadata] {path:?} is dirty."
+                    );
                     dirty = true;
                 }
             }


### PR DESCRIPTION
#
This PR enhances the debugging information related to the FURIOSA_METADATA_EXPECT_MODIFIED setting. It provides clearer insights into whether a file is considered 'dirty' or 'pass' based on the configured patterns.

Key changes:
- Add more detailed logging for files matching or not matching the FURIOSA_METADATA_EXPECT_MODIFIED patterns
- Clarify which patterns are working as expected and which are not

Motivation:
Previously, we had to rely on guesswork to determine if the patterns were functioning correctly. This lack of clear information made it difficult to debug and verify the behavior of the FURIOSA_METADATA_EXPECT_MODIFIED setting.

With these changes, we can:
1. Easily identify which files are being flagged as 'dirty' or 'pass'
2. Quickly verify if the configured patterns are working as intended
3. Reduce the time spent on debugging pattern-related issues

This improvement will significantly enhance our ability to manage and debug metadata-related configurations, leading to more efficient development and troubleshooting processes.

# LOG
ex) ```export FURIOSA_METADATA_EXPECT_MODIFIED=".cargo/**:Cargo.*:crates/**/*.py:crates/**/CMakeLists.txt"```
target/release/build/\<package>-\<hash>/stderr
```
FURIOSA_METADATA_EXPECT_MODIFIED=.cargo/**
FURIOSA_METADATA_EXPECT_MODIFIED=Cargo.*
FURIOSA_METADATA_EXPECT_MODIFIED=crates/**/*.py
FURIOSA_METADATA_EXPECT_MODIFIED=crates/**/CMakeLists.txt
[furiosa-metadata] Ignored an updated file ".cargo/config.toml" as it was expected.
[furiosa-metadata] Ignored an updated file "Cargo.lock" as it was expected.
[furiosa-metadata] Ignored an updated file "Cargo.toml" as it was expected.
[furiosa-metadata] Ignored an updated file "crates/xxxx/tests/python/ccc/xxxx.py" as it was expected.
[furiosa-metadata] Ignored an updated file "crates/xxxx/tests/python/ccc/xxxx2.py" as it was expected.
[furiosa-metadata] Ignored an updated file "crates/xxxxx/tests/python/furiosa_test_common/patch_torch.py" as it was expected.
[furiosa-metadata] Ignored an updated file "crates/npu-virtual-platform/CMakeLists.txt" as it was expected.
[furiosa-metadata] "crates/XXXXXXXX/include/interface/XXXXXX.hpp" is dirty.
```